### PR TITLE
angepasste Skriptversion für Enpal PV-Anlage mit Solar Rel v8.46.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-/.idea
-backup.sh

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ## Einbindung einer gemieteten EnPal PV-Anlage mittels InfluxDB in evcc
 Workaround für die evcc-Integration einer gemieteten Enpal PV-Anlage mit Enpal-Box. Zuletzt gestestet mit der IOT-Firmware "Solar Rel.8.46.4"
+an einer FoxESS-Anlage.
 
 KEINE EXTRA HARDWARE ODER ZUSATZMESSGERÄTE ERFORDERLICH! 
-Alle notwendigen Werte können über dieses Skript direkt aus der InfluxDB ausgelesen werden.
+Alle notwendigen Werte können mit diesem Skript direkt aus der InfluxDB ausgelesen werden. 
 
 Dieses Workaround basiert auf auf die tolle Vorarbeit von weldan84 mit unter dem Namen "enpal-influx-evcc". Vielen Dank hierfür :-)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-## Einbindung einer gemieteten PV-Anlage von Enpal mittels InfluxDB in evcc
-Workaround für die evcc-Integration einer gemieteten PV-Anlage "Huawei SUN2000 with SDongle &amp; Power Sensor" von Enpal.
+## Einbindung einer gemieteten EnPal PV-Anlage mittels InfluxDB in evcc
+Workaround für die evcc-Integration einer gemieteten PV-Anlage "FoxESS und Enpal-Box mit Solar Rel.8.46.4" von Enpal.
 
-Am 20. März 2023 hatte ich bei **evcc-io/evcc** auf GitHub eine [Diskussion](https://github.com/evcc-io/evcc/discussions/6965) bezüglich der Einbindung einer gemieteten PV-Anlage inkl. Speicher von Enpal gestellt. Allerdings stellte sich heraus, dass wohl niemand so recht etwas mit der Frage anzufangen wusste. Dazu muss man wissen, dass man bei einer gemieteten PV-Anlage von Enpal keinen Zugriff auf die Modbus-Schnittstelle erhält, man kann das System also nicht so einfach mittels [template](https://docs.evcc.io/docs/devices/meters#sun2000-with-sdongle--power-sensor) in die **evcc.yaml** einbinden.   
+Auf Anfrage beim technischen Support bei Enpal erhält man ein lesenden Zugang zur InfluxDB. Diese Datenbank befindet sich auf einem lokalen Server in der Enpal-Box. Laut E-Mail des technischen Beraters nutzt auch Enpal diese Datenbank für die hauseigene Enpal-App um Informationen aus der Anlage weiterzuverarbeiten. Ich bin jedoch der Meinung, dass nicht alle Daten in der InfluxDB zu finden sind, denn bis dato habe ich es z. B. noch nicht geschafft den Ladezustand des Speichers zu errechnen. Vielleicht bin ich aber auch einfach noch nicht tief genug in dem Thema drinn. Für Lösungsvorschläge diesbezüglich bin ich deshalb immer dankbar.
 
-Was man auf Anfrage vom technischen Support bei Enpal aber bekommt, ist ein lesender Zugang zur InfluxDB. Diese Datenbank befindet sich auf einem lokalen Server in der Enpal-Box. Laut E-Mail des technischen Beraters nutzt auch Enpal diese Datenbank für die hauseigene Enpal-App um Informationen aus der Anlage weiterzuverarbeiten. Ich bin jedoch der Meinung, dass nicht alle Daten in der InfluxDB zu finden sind, denn bis dato habe ich es z. B. noch nicht geschafft den Ladezustand des Speichers zu errechnen. Vielleicht bin ich aber auch einfach noch nicht tief genug in dem Thema drinn. Für Lösungsvorschläge diesbezüglich bin ich deshalb immer dankbar.
-
-Wichtig vorab zu wissen ist, dass meine Lösung für eine **InfluxDB in der Version 2.0.0** entwickelt wurde. Meines Wissens ist diese Version zumindest nicht mit den Vorgängern kompatibel. Laut den Informationen des technischen Mitarbeiters werden unter anderem an der Struktur der Datenbanken in diesem Jahr auch nochmal Änderungen vorgenommen, die dazu führen, dass Scripte evtl. angepasst werden müssen. Ich werde mich jedoch bemühen die Lösung hier stets auf den aktuellen Stand zu halten. Zudem läuft das Ganze bei mir auf einem kleinen **Server mit Ubuntu 20.04**.
+Wichtig vorab zu wissen ist, dass meine Lösung für eine **InfluxDB in der Version 2.2.0** entwickelt wurde. Meines Wissens ist diese Version zumindest nicht mit den Vorgängern kompatibel. Laut den Informationen des technischen Mitarbeiters werden unter anderem an der Struktur der Datenbanken in diesem Jahr auch nochmal Änderungen vorgenommen, die dazu führen, dass Scripte evtl. angepasst werden müssen.
 
 Was ihr also machen müsst, bevor ihr eure gemietete PV-Anlage in **evcc** einbinden könnt, ist eine freundliche E-Mail an den Enpal-Support zu schreiben und um lesenden Zugang für die InfluxDB zu bitten. In der Regel sollte eurer Bitte dann innerhalb von 1 bis 2 Werktagen Folge geleistet werden, meiner Erfahrung nach dauert es nicht länger bis man hier eine Antwort erhält.
 
@@ -16,14 +14,14 @@ In der Antwort-Mail sollte euch dann der lokale Host der InfluxDB sowie euer Ben
 4. Als nächstes benötigt ihr den **Token** zur Authentifizierung. Klickt dazu in der linken Navigationsleiste auf das Icon unter eurem Profilbild mit dem Subtitel "Data". Auf der darauffolgenden Seite solltet ihr im oberen Drittel mehrere Tabs sehen und ganz rechts einen mit der Aufschrift "Tokens". 
 5. Mit einem Klick auf den Tab gelangt ihr nun zur Übersicht eurer Tokens. Für gewöhnlich findet ihr hier lediglich einen Token, den ihr wiederum anklickt um im Anschluss den Schlüssel zu notieren.
 6. Ich bin mir aktuell nicht sicher ob die Buckets der InfluxDB nicht eigens für mich erstellt wurden oder ob der Name immer einheitlich ist. Zur Sicherheit würde ich nun nochmal auf den Tab "Buckets" klicken, der sich links vom Tab "Tokens" befindet und mir einen Überblick der angelegten Buckets verschaffen.
-7. Bei mir trägt der Bucket die Bezeichnung "my-new-bucket". Wenn ihr euch aber nicht sicher seid, dann klickt einfach auf den entsprechenen Bucket-Titel und prüft ob folgende Elemente angezeigt werden: "Gesamtleistung, LeistungDc, aggregated, consumtionEnergy, deviceStatus, fromGridEnergy, gridFrequency, intoGridEnergy, inverterTemperature, phaseCurrentAc, phasePowerAc, phaseVoltageAc, productionCurrentDc und productionVoltageDc"
-8. Werden diese Elemente angezeigt, dann notiert euch den entsprechenden **Bucket-Namen**.
+7. Bei mir trägt der Bucket die Bezeichnung "solar". Wenn ihr euch aber nicht sicher seid, dann klickt einfach auf den entsprechenen Bucket-Titel und prüft ob folgende Messurements angezeigt werden: "battery, system, inverter, powerSensor etc.""
+8. Werden diese Messurements angezeigt, notiert euch den entsprechenden **Bucket-Namen**.
 
 Um die PV-Anlage nun mittels evcc einzubinden geht wiefolgt vor:
 
 Ladet euch das Script herunter
 ````shell
-wget https://raw.githubusercontent.com/weldan84/enpal-influx-evcc/main/enpal.sh
+wget https://raw.githubusercontent.com/dl9cma/enpal-influx-evcc_SolarRel.8.46/main/enpal.sh
 ````
 
 Öffnet das Script und setzt eure Zugansdaten ein
@@ -64,10 +62,10 @@ sudo chmod +x /usr/bin/enpal
 
 Nun solltet ihr in der Lage sein das Script auch ohne "sh" und Pfadangabe aufzurufen
 ````shell
-enpal grid
+enpal evcc-gridpower
 ````
 
-Mit diesem Befehl sollte euch nun der aktuelle Netzbezug bzw. Einspeisung (mit einem negativen Wert) angezeigt werden
+Mit diesem Befehl sollte euch nun der aktuelle Netzbezug bzw. Einspeisung angezeigt werden
 
 Nun könnt ihr das [evcc-Plugin "script"](https://docs.evcc.io/docs/reference/plugins#shell-script-lesenschreiben) nutzen um eure Werte für grid, pv und battery weiterzuverarbeiten. Eine entsprechende Beispielkonfiguration der [evcc.yaml](https://github.com/weldan84/enpal-influx-evcc/blob/main/evcc.yaml) findet ihr ebenfalls [hier](https://github.com/weldan84/enpal-influx-evcc/blob/main/evcc.yaml) im Projektordner.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Einbindung einer gemieteten EnPal PV-Anlage mittels InfluxDB in evcc
 Workaround für die evcc-Integration einer gemieteten PV-Anlage "FoxESS und Enpal-Box mit Solar Rel.8.46.4" von Enpal.
 
+Diese Anpassung basiert auf enpal-influx-evcc von weldan84. Vielen Dank für die tolle Vorarbeit und Inspiration :-)
+
 Auf Anfrage beim technischen Support bei Enpal erhält man ein lesenden Zugang zur InfluxDB. Diese Datenbank befindet sich auf einem lokalen Server in der Enpal-Box. Laut E-Mail des technischen Beraters nutzt auch Enpal diese Datenbank für die hauseigene Enpal-App um Informationen aus der Anlage weiterzuverarbeiten. Ich bin jedoch der Meinung, dass nicht alle Daten in der InfluxDB zu finden sind, denn bis dato habe ich es z. B. noch nicht geschafft den Ladezustand des Speichers zu errechnen. Vielleicht bin ich aber auch einfach noch nicht tief genug in dem Thema drinn. Für Lösungsvorschläge diesbezüglich bin ich deshalb immer dankbar.
 
 Wichtig vorab zu wissen ist, dass meine Lösung für eine **InfluxDB in der Version 2.2.0** entwickelt wurde. Meines Wissens ist diese Version zumindest nicht mit den Vorgängern kompatibel. Laut den Informationen des technischen Mitarbeiters werden unter anderem an der Struktur der Datenbanken in diesem Jahr auch nochmal Änderungen vorgenommen, die dazu führen, dass Scripte evtl. angepasst werden müssen.
@@ -8,7 +10,7 @@ Wichtig vorab zu wissen ist, dass meine Lösung für eine **InfluxDB in der Vers
 Was ihr also machen müsst, bevor ihr eure gemietete PV-Anlage in **evcc** einbinden könnt, ist eine freundliche E-Mail an den Enpal-Support zu schreiben und um lesenden Zugang für die InfluxDB zu bitten. In der Regel sollte eurer Bitte dann innerhalb von 1 bis 2 Werktagen Folge geleistet werden, meiner Erfahrung nach dauert es nicht länger bis man hier eine Antwort erhält.
 
 In der Antwort-Mail sollte euch dann der lokale Host der InfluxDB sowie euer Benutzername und das Passwort mitgeteilt werden.
-1. Ruft nun die Weboberfläche der InfluxDB auf, indem ihr die **Host-Adresse zzgl. Port** (z.B. http://192.168.0.180:8086) im Browser eingebt. Meldet euch hier mit den entsprechenden Zugangsdaten an.
+1. Ruft nun die Weboberfläche der InfluxDB auf, indem ihr die **Host-Adresse zzgl. Port** (z.B. http://192.168.0.111:8086) im Browser eingebt. Meldet euch hier mit den entsprechenden Zugangsdaten an.
 2. Als erstes besorgt ihr euch die **Organization Id**. Klickt dazu in der linken Navigationsleiste unter dem Influx-Logo auf euer Profilbild. Es öffnet sich ein DropDown-Menü. Klickt dort nun auf "About".
 3. Nun sollten auf der rechten Seite der Webseite sogenannte "Common Ids" angezeigt werden, notiert euch hiervon die "Organization Id".
 4. Als nächstes benötigt ihr den **Token** zur Authentifizierung. Klickt dazu in der linken Navigationsleiste auf das Icon unter eurem Profilbild mit dem Subtitel "Data". Auf der darauffolgenden Seite solltet ihr im oberen Drittel mehrere Tabs sehen und ganz rechts einen mit der Aufschrift "Tokens". 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## Einbindung einer gemieteten EnPal PV-Anlage mittels InfluxDB in evcc
 Workaround für die evcc-Integration einer gemieteten Enpal PV-Anlage mit Enpal-Box. Zuletzt gestestet mit der IOT-Firmware "Solar Rel.8.46.4"
 
-KEINE EXTRA HARDWARE ODER ZUSATZMESSGERÄTE ERFORDERLICH! Alle notwendigen Werte können über dieses Skript direkt aus der InfluxDB ausgelesen werden.
+KEINE EXTRA HARDWARE ODER ZUSATZMESSGERÄTE ERFORDERLICH! 
+Alle notwendigen Werte können über dieses Skript direkt aus der InfluxDB ausgelesen werden.
 
 Dieses Workaround basiert auf auf die tolle Vorarbeit von weldan84 mit unter dem Namen "enpal-influx-evcc". Vielen Dank hierfür :-)
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@ Speichert die Änderungen mit der Tastenkombination "Strg+O" ab und schliesst di
 
 Ihr könnt das Script nun mit folgendem Befehl testen
 ````shell
-sh enpal.sh pv
+sh enpal.sh evcc-gridpower
 ````
-Als Ergebnis sollte euch die aktuelle DC-Erzeugungsleistung angezeigt werden, im Fehlerfall scheut euch bitte nicht hier unter [Issues](https://github.com/weldan84/enpal-influx-evcc/issues) einen neuen Vorgang aufzumachen.
+Als Ergebnis sollte euch die aktuelle Netzleistung angezeigt werden.
 
-Natürlich könnt ihr auch noch alle anderen Abfragen testen bevor ihr mit der Einbindung startet. Eine Liste aller möglichen Argumente erhaltet ihr mit dem Befehl
-````shell
-sh enpal.sh help
+Natürlich könnt ihr auch noch alle anderen Abfragen testen bevor ihr mit der Einbindung startet. Eine Liste aller möglichen Parameter (fields) könnt ihr in eurer InfluxDB einsehen.
+
+mit dem Befehl "enpal.sh 'messurement' 'field'" könnt ihr jedes beliebiges Feld aus der InfluxDB auslesen.
+
+Beispiel "enpal.sh inverter Power.DC.Total" zeigt den Wert des Feldes Power.DC.Total aus dem messurement inverter an. In diesem Fall wird die aktuelle Erzeugungsleistung aller Strings ausgegeben.
+
 ````
 
 Um das Script nun global bekannt zu machen, verschieben wir es in das bin-Verzeichnis und machen es ausführbar 
@@ -62,11 +65,11 @@ sudo chmod +x /usr/bin/enpal
 
 Nun solltet ihr in der Lage sein das Script auch ohne "sh" und Pfadangabe aufzurufen
 ````shell
-enpal evcc-gridpower
+enpal battery Energy.Battery.Charge.Level
 ````
 
-Mit diesem Befehl sollte euch nun der aktuelle Netzbezug bzw. Einspeisung angezeigt werden
+Mit diesem Befehl sollte euch nun der aktuelle ladestand eurer Batterie in % angezeigt werden
 
-Nun könnt ihr das [evcc-Plugin "script"](https://docs.evcc.io/docs/reference/plugins#shell-script-lesenschreiben) nutzen um eure Werte für grid, pv und battery weiterzuverarbeiten. Eine entsprechende Beispielkonfiguration der [evcc.yaml](https://github.com/weldan84/enpal-influx-evcc/blob/main/evcc.yaml) findet ihr ebenfalls [hier](https://github.com/weldan84/enpal-influx-evcc/blob/main/evcc.yaml) im Projektordner.
+Nun könnt ihr das [evcc-Plugin "script"](https://docs.evcc.io/docs/reference/plugins#shell-script-lesenschreiben) nutzen um eure Werte weiterzuverarbeiten. Eine entsprechende Beispielkonfiguration der evcc.yaml findet ihr hier im Projektordner.
 
 Zu Schluss möchte ich anmerken, dass ich mich noch nicht so lange mit dem Projekt evcc beschäftige. Es kann somit durchaus sein, dass hier oder da noch ein paar Denkfehler auftauchen. In diesem Fall freue ich mich über euren Rat. Im Gegenzug freue ich mich natürlich auch über positives Feedback, konstruktive Kritik und Verbesserungsvorschläge :)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Nun solltet ihr in der Lage sein das Script auch ohne "sh" und Pfadangabe aufzur
 enpal battery Energy.Battery.Charge.Level
 ````
 
-Mit diesem Befehl sollte euch nun der aktuelle ladestand eurer Batterie in % angezeigt werden
+Mit diesem Befehl sollte euch nun der aktuelle Ladestand eurer Batterie in % angezeigt werden
 
 Nun könnt ihr das [evcc-Plugin "script"](https://docs.evcc.io/docs/reference/plugins#shell-script-lesenschreiben) nutzen um eure Werte weiterzuverarbeiten. Eine entsprechende Beispielkonfiguration der evcc.yaml findet ihr hier im Projektordner.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 ## Einbindung einer gemieteten EnPal PV-Anlage mittels InfluxDB in evcc
-Workaround für die evcc-Integration einer gemieteten PV-Anlage "FoxESS und Enpal-Box mit Solar Rel.8.46.4" von Enpal.
+Workaround für die evcc-Integration einer gemieteten Enpal PV-Anlage mit Enpal-Box. Zuletzt gestestet mit der IOT-Firmware "Solar Rel.8.46.4"
 
-Diese Anpassung basiert auf enpal-influx-evcc von weldan84. Vielen Dank für die tolle Vorarbeit und Inspiration :-)
+KEINE EXTRA HARDWARE ODER ZUSATZMESSGERÄTE ERFORDERLICH! Alle notwendigen Werte können über dieses Skript direkt aus der InfluxDB ausgelesen werden.
+
+Dieses Workaround basiert auf auf die tolle Vorarbeit von weldan84 mit unter dem Namen "enpal-influx-evcc". Vielen Dank hierfür :-)
 
 Auf Anfrage beim technischen Support bei Enpal erhält man ein lesenden Zugang zur InfluxDB. Diese Datenbank befindet sich auf einem lokalen Server in der Enpal-Box. Laut E-Mail des technischen Beraters nutzt auch Enpal diese Datenbank für die hauseigene Enpal-App um Informationen aus der Anlage weiterzuverarbeiten. Ich bin jedoch der Meinung, dass nicht alle Daten in der InfluxDB zu finden sind, denn bis dato habe ich es z. B. noch nicht geschafft den Ladezustand des Speichers zu errechnen. Vielleicht bin ich aber auch einfach noch nicht tief genug in dem Thema drinn. Für Lösungsvorschläge diesbezüglich bin ich deshalb immer dankbar.
 
-Wichtig vorab zu wissen ist, dass meine Lösung für eine **InfluxDB in der Version 2.2.0** entwickelt wurde. Meines Wissens ist diese Version zumindest nicht mit den Vorgängern kompatibel. Laut den Informationen des technischen Mitarbeiters werden unter anderem an der Struktur der Datenbanken in diesem Jahr auch nochmal Änderungen vorgenommen, die dazu führen, dass Scripte evtl. angepasst werden müssen.
+Wichtig vorab zu wissen ist, dass diese Lösung für eine **InfluxDB in der Version 2.2.0** entwickelt wurde. Es handelt sich hierbei um eine Version welche nicht mit den Vorgängern kompatibel sein dürfte. 
 
 Was ihr also machen müsst, bevor ihr eure gemietete PV-Anlage in **evcc** einbinden könnt, ist eine freundliche E-Mail an den Enpal-Support zu schreiben und um lesenden Zugang für die InfluxDB zu bitten. In der Regel sollte eurer Bitte dann innerhalb von 1 bis 2 Werktagen Folge geleistet werden, meiner Erfahrung nach dauert es nicht länger bis man hier eine Antwort erhält.
 

--- a/enpal.sh
+++ b/enpal.sh
@@ -2,223 +2,165 @@
 
 # Zugangsdaten InfluxDB
 # @ see https://github.com/weldan84/enpal-influx-evcc
-INFLUX_HOST="YOUR_INFLUX_HOST"
-INFLUX_ORG_ID="YOUR_INFLUX_ORG_ID"
-INFLUX_BUCKET="YOUR_INFLUX_BUCKET"
-INFLUX_TOKEN="YOUR_INFLUX_TOKEN"
+INFLUX_HOST="ip-adresse:8086"
+INFLUX_ORG_ID="orgidausinfluxdb"
+INFLUX_BUCKET="solar"
+INFLUX_TOKEN="einelangekryptischezeichenkette"
 INFLUX_API="${INFLUX_HOST}/api/v2/query?orgID=${INFLUX_ORG_ID}"
 QUERY_RANGE_START="-5m"
 
-# Zugangsdaten Powerfox Poweropti
-# @see https://www.powerfox.energy/daten-von-powerfox-per-api-nutzen/
-POWERFOX_USERNAME="POWERFOX_USERNAME"
-POWERFOX_PASSWORD="POWERFOX_PASSWORD"
-POWERFOX_DEVICE_ID="POWERFOX_DEVICE_ID"
 
 case $1 in
-# Gesamtverbrauch
-consumption)
-  var=$(curl -f -s "${INFLUX_API}" \
-    --header "Authorization: Token ${INFLUX_TOKEN}" \
-    --header "Accept: application/json" \
-    --header "Content-type: application/vnd.flux" \
-    --data "from(bucket: \"$INFLUX_BUCKET\")
-            |> range(start: $QUERY_RANGE_START)
-            |> filter(fn: (r) => r._measurement == \"Gesamtleistung\")
-            |> filter(fn: (r) => r._field == \"Verbrauch\")
-            |> keep(columns: [\"_value\"])
-            |> last()")
-  status="$?"
-  var="${var##*,}"
-  ;;
-# Netzbezug/Einspeisung Enpal InfluxDB (Errechneter Wert)
-grid_enpal)
-  pv=$(enpal pv)
-  consumption=$(enpal consumption)
-  battery=$(enpal battery)
-  # shellcheck disable=SC2004
-  echo $(($consumption - $pv - $battery))
-  exit 0
-  ;;
-# Netzbezug/Einspeisung Powerfox Poweropti (Tatsächlicher Wert)
-grid_powerfox)
-  # Um das API-Aufrufkontingent nicht zu überschreiten wird hier 3 Sekunden lang pausiert! (Maximal zugelassen 1 pro 3s)
-  sleep 3
-  var=$(curl -f -s -G "https://backend.powerfox.energy/api/2.0/my/$POWERFOX_DEVICE_ID/current" \
-    -u "$POWERFOX_USERNAME:$POWERFOX_PASSWORD")
-  status="$?"
-  var=$(echo "$var" | jq '.Watt // empty')
-  if [ "$var" = "empty" ]; then
-    echo >&2 "Der Poweropti liefert keine aktuellen Werte. Hier wird dir geholfen https://poweropti.powerfox.energy/faq/"
-    exit 1
-  fi
-  echo "$var"
-  exit "$status"
-  ;;
-# Aktuelle Solarproduktion / DC-Erzeugungsleistung
-pv)
-  var=$(curl -f -s "${INFLUX_API}" \
-    --header "Authorization: Token ${INFLUX_TOKEN}" \
-    --header "Accept: application/json" \
-    --header "Content-type: application/vnd.flux" \
-    --data "from(bucket: \"$INFLUX_BUCKET\")
-            |> range(start: $QUERY_RANGE_START)
-            |> filter(fn: (r) => r._measurement == \"LeistungDc\")
-            |> filter(fn: (r) => r._field == \"Total\")
-            |> keep(columns: [\"_value\"])
-            |> last()")
-  status="$?"
-  var="${var##*,}"
-  ;;
-# Kumulierte Solarproduktion / DC-Erzeugungsleistung
-energy)
-  var=$(curl -f -s "${INFLUX_API}" \
-    --header "Authorization: Token ${INFLUX_TOKEN}" \
-    --header "Accept: application/json" \
-    --header "Content-type: application/vnd.flux" \
-    --data "from(bucket: \"$INFLUX_BUCKET\")
-            |> range(start: $QUERY_RANGE_START)
-            |> filter(fn: (r) => r._measurement == \"aggregated\")
-            |> filter(fn: (r) => r._field == \"Produktion\")
-            |> keep(columns: [\"_value\"])
-            |> last()")
-  status="$?"
-  var="${var##*,}"
-  ;;
-# Aktuelle Produktion der Phasen 1 bis 3
-phase)
-  if [ -z "$2" ]; then
-    echo >&2 "The phase number must be passed as an argument"
-    exit 1
-  else
-    case $2 in
-    1)
-      var=$(curl -f -s "${INFLUX_API}" \
-        --header "Authorization: Token ${INFLUX_TOKEN}" \
-        --header "Accept: application/json" \
-        --header "Content-type: application/vnd.flux" \
-        --data "from(bucket: \"$INFLUX_BUCKET\")
-               |> range(start: $QUERY_RANGE_START)
-               |> filter(fn: (r) => r._measurement == \"phasePowerAc\")
-               |> filter(fn: (r) => r._field == \"Phase1\")
-               |> keep(columns: [\"_value\"])
-               |> last()")
-      ;;
-    2)
-      var=$(curl -f -s "${INFLUX_API}" \
-        --header "Authorization: Token ${INFLUX_TOKEN}" \
-        --header "Accept: application/json" \
-        --header "Content-type: application/vnd.flux" \
-        --data "from(bucket: \"$INFLUX_BUCKET\")
-               |> range(start: $QUERY_RANGE_START)
-               |> filter(fn: (r) => r._measurement == \"phasePowerAc\")
-               |> filter(fn: (r) => r._field == \"Phase2\")
-               |> keep(columns: [\"_value\"])
-               |> last()")
-      ;;
-    3)
-      var=$(curl -f -s "${INFLUX_API}" \
-        --header "Authorization: Token ${INFLUX_TOKEN}" \
-        --header "Accept: application/json" \
-        --header "Content-type: application/vnd.flux" \
-        --data "from(bucket: \"$INFLUX_BUCKET\")
-               |> range(start: $QUERY_RANGE_START)
-               |> filter(fn: (r) => r._measurement == \"phasePowerAc\")
-               |> filter(fn: (r) => r._field == \"Phase3\")
-               |> keep(columns: [\"_value\"])
-               |> last()")
-      ;;
-    *)
-      echo >&2 "The phase number is invalid"
-      exit 1
-      ;;
-    esac
-    status="$?"
-    var="${var##*,}"
-  fi
-  ;;
-# Wechselstromleistung
-ac)
-  var=$(curl -f -s "${INFLUX_API}" \
-    --header "Authorization: Token ${INFLUX_TOKEN}" \
-    --header "Accept: application/json" \
-    --header "Content-type: application/vnd.flux" \
-    --data "from(bucket: \"$INFLUX_BUCKET\")
-           |> range(start: $QUERY_RANGE_START)
-           |> filter(fn: (r) => r._measurement == \"phasePowerAc\")
-           |> filter(fn: (r) => r._field == \"Total\")
-           |> keep(columns: [\"_value\"])
-           |> last()")
-  status="$?"
-  var="${var##*,}"
-  ;;
-# Batterieleistung
-# Die maximale Entladeleistung ist auf 5000W begrenzt, die maximale Ladeleistung auf -5000W. Dieser Wert kann/muss je nach Speicher angepasst werden.
-battery)
-  pv=$(enpal pv)
-  ac=$(enpal ac)
-  if [ "$POWERFOX_USERNAME" = "POWERFOX_USERNAME" ] || [ "$POWERFOX_PASSWORD" = "POWERFOX_PASSWORD" ]; then
-    # Falls Powerfox Poweropti nicht genutzt wird, muss der Ladezustand geschätzt werden
-    if [ "$ac" -lt "$pv" ]; then
-      echo 0
-      exit 0
-    else
-      battery=$(($ac - $pv))
-      if [ "$battery" -lt -5000 ]; then
-        echo -5000
-        exit 0
-      elif [ "$battery" -gt 5000 ]; then
-        echo 5000
-        exit 0
-      fi
-    fi
-  else
-    # Falls Powerfox Poweropti vorhanden ist, kann mit Sicherheit bestimmt werden wie hoch die
-    # Batterieleistung ist, indem die Werte für den tatsächlichen Netzbezug mit einberechnet werden.
-    grid=$(enpal grid_powerfox)
-    if [ "$grid" -gt 0 ] && [ "$ac" -lt "$pv" ]; then
-      echo 0
-    else
-      battery=$(($ac - $pv + $grid))
-    fi
-  fi
-
-  echo "$battery"
-  exit 0
-  ;;
-# Ladezustand der Batterie (bisher nur 0%, 50% oder 100% möglich)
-# Momentan werden durch Enpal in der InfluxDB noch nicht die nötigen Daten bereitgestellt um den genauen Ladezustand bestimmen zu können.
-# Ist die Batterieleistung gleich 0 und die DC-Erzeugungsleistung größer als 0 kann davon ausgegangen werden, dass die Batterie zu 100% geladen ist. Beträgt
-# die Batterieleistung jedoch 0 und die DC-Erzeugungsleistung ebenso 0, ist die Batterie vollständig entladen. Alles dazwischen erhält aktuell den Wert 50%.
-soc)
-  pv=$(enpal pv)
-  battery=$(enpal battery)
-  if [ "$battery" -eq 0 ] && [ "$pv" -gt 0 ]; then
-    echo 100
-  elif [ "$battery" -eq 0 ]; then
-    echo 0
-  else
-    echo 50
-  fi
-  exit 0
-  ;;
-# Kleine Gedankenstütze für die Konsole ;)
-help)
-  echo consumption
-  echo grid_enpal
-  echo grid_powerfox
-  echo pv
-  echo energy
-  echo phase \[1-3\]
-  echo ac
-  echo battery
-  echo soc
-  exit 0
-  ;;
-*)
-  echo >&2 "The argument for the desired meter value is missing or invalid"
-  exit 1
-  ;;
+	battery)
+	    if [ -z "$2" ]; then
+	    echo >&2 "Geben Sie ein gültigen Sensor Namen für ihre Messung an."
+	    echo >&2 "Schauen Sie hierzu in die InfluxDB oder Webseite ihrer EnpalBox"
+	    exit 1
+	    else
+		var=$(curl -f -s "${INFLUX_API}" \
+		    --header "Authorization: Token ${INFLUX_TOKEN}" \
+		    --header "Accept: application/json" \
+		    --header "Content-type: application/vnd.flux" \
+		    --data "from(bucket: \"$INFLUX_BUCKET\")
+			|> range(start: $QUERY_RANGE_START)
+			|> filter(fn: (r) => r._measurement == \"battery\")
+			|> filter(fn: (r) => r._field == \"$2\")
+			|> keep(columns: [\"_value\"])
+			|> last()")
+		status="$?"
+		var="${var##*,}"
+	    fi
+	    ;;
+	inverter)
+	    if [ -z "$2" ]; then
+	    echo >&2 "Geben Sie ein gültigen Sensor Namen für ihre Messung an."
+	    echo >&2 "Schauen Sie hierzu in ihrer InfluxDB oder Webseite ihrer EnpalBox"
+	    exit 1
+        else
+		var=$(curl -f -s "${INFLUX_API}" \
+		    --header "Authorization: Token ${INFLUX_TOKEN}" \
+		    --header "Accept: application/json" \
+		    --header "Content-type: application/vnd.flux" \
+		    --data "from(bucket: \"$INFLUX_BUCKET\")
+			|> range(start: $QUERY_RANGE_START)
+			|> filter(fn: (r) => r._measurement == \"inverter\")
+			|> filter(fn: (r) => r._field == \"$2\")
+			|> keep(columns: [\"_value\"])
+			|> last()")
+		status="$?"
+		var="${var##*,}"
+	    fi
+	;;
+	iot)
+	    if [ -z "$2" ]; then
+	    echo >&2 "Geben Sie ein gueltigen Sensor Namen fuer ihre Messung an."
+	    echo >&2 "Schauen Sie hierzu in ihrer InfluxDB oder Webseite ihrer EnpalBox"
+	    exit 1
+	    else
+		var=$(curl -f -s "${INFLUX_API}" \
+		    --header "Authorization: Token ${INFLUX_TOKEN}" \
+		    --header "Accept: application/json" \
+		    --header "Content-type: application/vnd.flux" \
+		    --data "from(bucket: \"$INFLUX_BUCKET\")
+			|> range(start: $QUERY_RANGE_START)
+			|> filter(fn: (r) => r._measurement == \"iot\")
+			|> filter(fn: (r) => r._field == \"$2\")
+			|> keep(columns: [\"_value\"])
+			|> last()")
+		status="$?"
+		var="${var##*,}"
+	    fi
+	;;
+	powerSensor)
+	    if [ -z "$2" ]; then
+	    echo >&2 "Geben Sie ein gültigen Sensor Namen für ihre Messung an."
+	    echo >&2 "Schauen Sie hierzu in ihrer InfluxDB oder Webseite ihrer EnpalBox"
+	    exit 1
+	    else
+		var=$(curl -f -s "${INFLUX_API}" \
+		    --header "Authorization: Token ${INFLUX_TOKEN}" \
+		    --header "Accept: application/json" \
+		    --header "Content-type: application/vnd.flux" \
+		    --data "from(bucket: \"$INFLUX_BUCKET\")
+			|> range(start: $QUERY_RANGE_START)
+			|> filter(fn: (r) => r._measurement == \"powerSensor\")
+			|> filter(fn: (r) => r._field == \"$2\")
+			|> keep(columns: [\"_value\"])
+			|> last()")
+		status="$?"
+		var="${var##*,}"
+	    fi
+	;;
+	system)
+	    if [ -z "$2" ]; then
+	    echo >&2 "Geben Sie ein gültigen Sensor Namen für ihre Messung an."
+	    echo >&2 "Schauen Sie hierzu in ihrer InfluxDB oder Webseite ihrer EnpalBox"
+	    exit 1
+	    else
+		var=$(curl -f -s "${INFLUX_API}" \
+		    --header "Authorization: Token ${INFLUX_TOKEN}" \
+		    --header "Accept: application/json" \
+		    --header "Content-type: application/vnd.flux" \
+		    --data "from(bucket: \"$INFLUX_BUCKET\")
+			|> range(start: $QUERY_RANGE_START)
+			|> filter(fn: (r) => r._measurement == \"system\")
+			|> filter(fn: (r) => r._field == \"$2\")
+			|> keep(columns: [\"_value\"])
+			|> last()")
+		status="$?"
+		var="${var##*,}"
+	    fi
+	;;
+	evcc-battery)
+		var=$(curl -f -s "${INFLUX_API}" \
+		    --header "Authorization: Token ${INFLUX_TOKEN}" \
+		    --header "Accept: application/json" \
+		    --header "Content-type: application/vnd.flux" \
+		    --data "from(bucket: \"$INFLUX_BUCKET\")
+			|> range(start: $QUERY_RANGE_START)
+			|> filter(fn: (r) => r._measurement == \"battery\")
+			|> filter(fn: (r) => r._field == \"Power.Battery.Charge.Discharge\")
+			|> keep(columns: [\"_value\"])
+			|> last()")
+		status="$?"
+		var="${var##*,}"
+                echo $((var * -1))    
+		exit "$status"
+	;;
+	evcc-gridpower)
+		var=$(curl -f -s "${INFLUX_API}" \
+		    --header "Authorization: Token ${INFLUX_TOKEN}" \
+		    --header "Accept: application/json" \
+		    --header "Content-type: application/vnd.flux" \
+		    --data "from(bucket: \"$INFLUX_BUCKET\")
+			|> range(start: $QUERY_RANGE_START)
+			|> filter(fn: (r) => r._measurement == \"inverter\")
+			|> filter(fn: (r) => r._field == \"Power.Grid.Export\")
+			|> keep(columns: [\"_value\"])
+			|> last()")
+		status="$?"
+                var="${var##*,}"
+                echo $((var * -1))
+                exit "$status"
+	;;
+	*)
+	echo >&2 "Geben Sie eine gültige Messung (_measurement) und den dazugehören Sensornamen (_field) aus ihrer InfluxDB an."
+	echo >&2 ""
+	echo >&2 "enpal <_measurement> <_field>"
+	echo >&2 ""
+	echo >&2 "Derzeit stehen Ihnen mit der 'Enpal Solar Rel.8.46.4' folgende measurements zur verfügung:"
+	echo <&2 "'battery', 'inverter', 'iot', 'powerSensor' und 'system'"
+        exit 1
+	;;
+	*)
+	echo >&2 "Geben Sie eine gültige Messung (_measurement) und den dazugehören Sensornamen (_field) aus ihrer InfluxDB an."
+	echo >&2 ""
+	echo >&2 "enpal <_measurement> <_field>"
+	echo >&2 ""
+	echo >&2 "Derzeit stehen Ihnen mit der 'Enpal Solar Rel.8.46.4' folgende measurements zur verfügung:"
+	echo <&2 "'battery', 'inverter', 'iot', 'powerSensor' und 'system'"
+        exit 1
+	;;
 esac
 
 # Konvertierung

--- a/evcc.yaml
+++ b/evcc.yaml
@@ -1,55 +1,73 @@
-# Für weitere Konfigurationsmöglichkeiten siehe offizielle Referenz unter https://docs.evcc.io/docs/reference/configuration/
-site:
-  - title: Zuhause
-    meters:
-      grid: grid_enpal #grid_powerfox optional
-      pv:
-        - pv
-      battery:
-        - battery
-    residualPower: 100
-    bufferSoc: 60
-    prioritySoc: 40
-interval: 30s
-network:
-  schema: http
-  host: evcc.local
-  port: 7070
-levels:
-  site: debug
-  meters: debug
-  lp-1: debug
 meters:
   - name: grid_enpal
     type: custom
     power:
       source: script
-      cmd: enpal grid_enpal
-      timeout: 10s
-  - name: grid_powerfox #optional
-    type: custom
-    power:
-      source: script
-      cmd: enpal grid_powerfox
-      timeout: 10s
-  - name: pv
-    type: custom
-    power:
-      source: script
-      cmd: enpal pv
+      cmd: enpal evcc-gridpower
       timeout: 10s
     energy:
       source: script
-      cmd: enpal energy
+      cmd: enpal system Energy.External.Total.In.Day
       timeout: 10s
-  - name: battery
+    currents:
+      - source: script
+        cmd: enpal powerSensor Current.Phase.A
+        timeout: 10s
+      - source: script
+        cmd: enpal powerSensor Current.Phase.B
+        timeout: 10s
+      - source: script
+        cmd: enpal powerSensor Current.Phase.C
+        timeout: 10s
+
+  - name: pv_enpal
     type: custom
     power:
       source: script
-      cmd: enpal battery
+      cmd: enpal inverter Power.DC.Total
+      timeout: 10s
+    energy:
+      source: script
+      cmd: enpal inverter Energy.Production.Total.Day
+      timeout: 10s
+    currents:
+      - source: script
+        cmd: enpal inverter Current.String.1
+        timeout: 10s
+      - source: script
+        cmd: enpal inverter Current.String.2
+        timeout: 10s
+      - source: script
+        cmd: enpal inverter Current.String.3
+        timeout: 10s
+
+  - name: battery_enpal
+    type: custom
+    power:
+      source: script
+      cmd: enpal evcc-battery
       timeout: 10s
     soc:
       source: script
-      cmd: enpal soc
+      cmd: enpal battery Energy.Battery.Charge.Level
       timeout: 10s
     capacity: 10
+
+  - name: home_consumption
+    type: custom
+    power:
+      source: script
+      cmd: enpal inverter Power.House.Total
+      timeout: 10s
+    energy:
+       source: script
+       cmd: enpal system Energy.Consumption.Total.Day
+       timeout: 10s
+site:
+  title: Mein Zuhause
+  meters:
+    grid: grid_enpal
+    pv: pv_enpal
+    battery: battery_enpal
+    aux: home_consumption
+    #ext: 


### PR DESCRIPTION
angepasste Skriptversion für Enpal PV-Anlage mit Solar Rel v8.46. Des Weiteren verwendet dieses Skript eine universelle Abfrage via messurement und fields. Somit können fast alle Wert aus der Influx DB via Skriptbefehl abgerufen werden. Um eine Übersicht der möglichen Messwerte zu erhalten, sollten Sie sich zuvor Inhalte ihrer InfluxDB einsehen. Um das Skript zu verschlanken wurde PowerfoxOpti vorerst wieder entfernt.  